### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # XBSettingController
 简单配置即可快速搭建类个人中心及应用设置界面
 
-##效果图
+## 效果图
 ![效果图](https://github.com/changjianfeishui/XBSettingController/raw/master/2.gif)
 
-##参数说明
+## 参数说明
 
 ![参数图](https://github.com/changjianfeishui/XBSettingController/raw/master/1.png)
 
 ![参数图](https://github.com/changjianfeishui/XBSettingController/raw/master/3.png)
 
 
-##使用说明
+## 使用说明
 
 使用方法参见Demo,本来打算封装一个基类供继承使用,但这样可定制性就差了,因此使用还是需要实现UITableView的dataSource和delegate,如果效果图中效果可以满足需求的话,可以直接复制使用.否则,更细致的定制修改请自行修改相关源码.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
